### PR TITLE
fixed as requested, this branch removes the Example, pages last week

### DIFF
--- a/src/components/home/button.tsx
+++ b/src/components/home/button.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+
+interface ButtonProps {
+  textColor: string;
+  background: string;
+  borderColor: string;
+  text: string;
+  link: string;
+}
+
+const Button = ({
+  textColor,
+  background,
+  borderColor,
+  text,
+  link,
+}: ButtonProps) => {
+  return (
+    <Link
+      href={link}
+      className="w-1/5 rounded-md border-1 py-2 text-center"
+      style={{
+        color: textColor,
+        backgroundColor: background,
+        borderColor: borderColor,
+      }}
+    >
+      {text}
+    </Link>
+  );
+};
+
+export default Button;


### PR DESCRIPTION
fixed according to suggestions. However, I can't fix tailwind inline class name since dynamic classnames are janky or just don't work (https://stackoverflow.com/questions/69687530/how-to-build-dynamically-class-names-with-tailwind-css) and I have to handle cases of variable names etc , so I just kept with the original code since it works for variable names, literals, and hex.

example:
<img width="440" height="96" alt="image" src="https://github.com/user-attachments/assets/2c5b595b-c85c-4b0a-adff-17c382b10deb" />
code:

<Button
textColor="white" // literal color
background="var(--color-pickleball-blue-100)" // CSS variable
borderColor="#f00"
text="Highlander Link Application"
link="/explore"
/ >
