### PR TITLE
Implemented paddle component

### DIFF
--- a/src/components/home/paddle.tsx
+++ b/src/components/home/paddle.tsx
@@ -10,7 +10,7 @@ interface PaddleProps {
 const Paddle = ({ text, number, className }: PaddleProps) => {
   return (
     <div className={`m-4 flex items-center justify-center ${className}`}>
-      <div className={`relative ${"h-sm w-sm"}`}>
+      <div className="h-sm relative w-sm">
         <Image
           src={whitePaddle}
           alt="white paddle"


### PR DESCRIPTION
Limited component for now. Takes in a string and a number. Only has it right-side up and when changing the size of it, the string will not properly be responsive to the paddle size. 
<img width="1097" height="514" alt="image" src="https://github.com/user-attachments/assets/e0f794d4-d846-49bf-b80f-7ce9f8fdc953" />
