### PR TITLE
Mobile responsiveness changes

### DIFF
--- a/src/components/home/paddle.tsx
+++ b/src/components/home/paddle.tsx
@@ -11,7 +11,7 @@ interface PaddleProps {
 const Paddle = ({ text, number, className, rotated = false }: PaddleProps) => {
   return (
     <div
-      className={`relative m-12 flex items-center justify-center ${rotated ? "lg:rotate-180" : ""} ${className}`}
+      className={`relative m-12 flex items-center justify-center ${rotated ? "xl:rotate-180" : ""} ${className}`}
     >
       <Image
         src={whitePaddle}
@@ -21,20 +21,20 @@ const Paddle = ({ text, number, className, rotated = false }: PaddleProps) => {
 
       {!rotated ? (
         <>
-          <div className="text-pickleball-green-100 absolute inset-x-8 inset-y-12 flex justify-center text-center text-2xl leading-relaxed font-bold tracking-wide lg:inset-x-16 lg:inset-y-16 lg:text-4xl">
+          <div className="text-pickleball-green-100 absolute inset-x-6 inset-y-12 flex justify-center text-center text-2xl leading-relaxed font-bold tracking-wide md:inset-x-20 md:text-4xl lg:inset-x-10 lg:inset-y-16 lg:mt-0 lg:text-4xl xl:inset-x-6">
             {text}
           </div>
 
-          <div className="text-pickleball-green-100 absolute inset-x-2 inset-y-4 mt-24 flex items-center justify-center text-center text-4xl font-bold lg:text-6xl">
+          <div className="text-pickleball-green-100 absolute inset-x-2 inset-y-4 mt-24 flex items-center justify-center text-center text-4xl font-bold md:pt-8 md:text-5xl lg:pt-4 lg:text-6xl">
             {number}
           </div>
         </>
       ) : (
         <>
-          <div className="lg:text-pickleball-green-100 absolute inset-x-5 inset-y-12 ml-4 flex justify-center pr-4 text-center text-2xl leading-relaxed font-bold tracking-wide lg:inset-x-6 lg:inset-y-88 lg:mr-6 lg:mb-4 lg:ml-2 lg:rotate-180 lg:text-4xl">
+          <div className="text-pickleball-green-100 absolute inset-x-1 inset-y-12 ml-4 flex justify-center pr-4 text-center text-2xl leading-relaxed font-bold tracking-wide md:inset-x-15 md:text-4xl lg:inset-x-6 lg:inset-y-20 lg:mt-0 lg:mb-4 lg:ml-2 lg:text-4xl xl:inset-y-88 xl:mr-6 xl:rotate-180">
             {text}
           </div>
-          <div className="lg:text-pickleball-green-100 absolute inset-x-15 inset-y-2 mt-24 ml-4 flex items-center justify-center pr-4 text-center text-4xl font-bold lg:mr-8 lg:rotate-180 lg:text-6xl">
+          <div className="text-pickleball-green-100 absolute inset-x-15 inset-y-2 mt-24 ml-4 flex items-center justify-center pr-4 text-center text-4xl font-bold md:pt-8 md:text-5xl lg:text-6xl xl:mr-8 xl:rotate-180">
             {number}
           </div>
         </>

--- a/src/components/home/paddles.tsx
+++ b/src/components/home/paddles.tsx
@@ -3,13 +3,13 @@ import { paddles } from "@/data/paddle";
 
 const Paddles = () => {
   return (
-    <div className="lg:flex-flow mt-16 flex flex-col items-center justify-center lg:flex-wrap">
-      <div className="m-5 flex flex-col items-center justify-center lg:flex-row">
+    <div className="xl:flex-flow mt-16 flex flex-col items-center justify-center xl:flex-wrap">
+      <div className="m-5 flex flex-col items-center justify-center xl:flex-row">
         {paddles.slice(0, 3).map(({ text, number }, index) => (
           <Paddle key={index} text={text} number={number} />
         ))}
       </div>
-      <div className="lmr-8 m-5 -mt-5 flex flex-col items-center justify-center lg:-mt-60 lg:flex-row">
+      <div className="lmr-8 m-5 -mt-5 flex flex-col items-center justify-center xl:-mt-60 xl:flex-row">
         {paddles.slice(3).map(({ text, number }, index) => (
           <Paddle key={index + 3} text={text} number={number} rotated={true} />
         ))}


### PR DESCRIPTION
Made last two paddles rightside up rather than upside down for mobile. 
<img width="460" height="816" alt="image" src="https://github.com/user-attachments/assets/d457175f-a429-4e1a-a33a-a5f3a9764f0a" />
<img width="460" height="818" alt="image" src="https://github.com/user-attachments/assets/1618ac41-5b39-4da9-9a9e-df6facf31a50" />

Desktop:
<img width="1565" height="831" alt="image" src="https://github.com/user-attachments/assets/e35d5fc0-4d95-4cb8-b107-d0b9f43a95ca" />
